### PR TITLE
Always statically link libstdc++

### DIFF
--- a/ci
+++ b/ci
@@ -104,10 +104,7 @@ rustflags = [${lib_search_args%,}]
 EOF
     elif [[ "$TARGET" != *darwin* ]]
     then
-        if [[ "$TARGET" == *musl* ]]
-        then extra_args='"-l", "static=stdc++"'
-        else extra_args='"-l", "stdc++"'
-        fi
+        extra_args='"-l", "static=stdc++"'
 
         target_search_args=$(print-gcc-search-args "$TARGET-g++")
         host_search_args=$(print-gcc-search-args "g++")
@@ -147,7 +144,7 @@ rustflags = [$extra_args, ${target_search_args%,}]
 
 [build]
 linker = "g++"
-rustflags = [${host_search_args%,}]
+rustflags = [$extra_args, ${host_search_args%,}]
 EOF
     fi
 }


### PR DESCRIPTION
This avoids having to be compatible with old C++ ABIs