### PR TITLE
Introduces Baseline Header Interface

### DIFF
--- a/serde-avro/src/header.rs
+++ b/serde-avro/src/header.rs
@@ -1,9 +1,28 @@
 use serde;
-use std::collections;
+use std::{collections};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Header {
     pub magic: serde::bytes::ByteBuf,
     pub meta: collections::HashMap<String, serde::bytes::ByteBuf>,
     pub sync: serde::bytes::ByteBuf,
+}
+
+impl Header {
+
+    /// Returns a copy of the given header's name field as a String.
+    pub fn name(&self) -> String {
+        let raw = self.get("name").expect("No name present in Avro schema!");
+        String::from_utf8(raw.to_vec()).expect("Failed to decode name!")
+    }
+
+    /// Returns a copy of the raw bytes stored at the given key
+    /// for the given header.
+    pub fn get(&self, key: &str) -> Option<serde::bytes::ByteBuf> {
+        if let Some(bytes) = self.meta.get(key) {
+            Some(bytes.clone())
+        } else {
+            None
+        }
+    }
 }


### PR DESCRIPTION
It is useful to be able to inspect an Avro header.  For
example, to assert certain naming conventions are met prior to ingestion.

The following changes have been made to expose header values to users:

* Header now exposes an interface into its metadata.  Said interface
  users to retrieve the schema's name as a string and retrieve copies of
  metadata value by key.

* Deserializer now stores the parsed header.  This new value is used by
  a new callback, `name`, which reaches into the parsed header and
  returns the name contained in the header's metadata.