### PR TITLE
Make v8 (and query engine) optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,21 +1,3 @@
-[root]
-name = "serde-avro"
-version = "0.5.0"
-dependencies = [
- "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crc 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "flate2 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde-value 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "snap 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "aho-corasick"
 version = "0.5.3"
@@ -564,6 +546,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "serde"
 version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde-avro"
+version = "0.5.0"
+dependencies = [
+ "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-value 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snap 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "serde-hjson"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ serde-protobuf = "0.5.0"
 serde_cbor = "0.5.0"
 serde_json = "0.9.6"
 serde_yaml = "0.6.0"
-v8 = "0.9.1"
 xdg-basedir = "1.0.0"
 yaml-rust = "0.3.5"
 
@@ -56,8 +55,13 @@ version = "0.5.0"
 features = ["serde"]
 version = "0.3.0"
 
+[dependencies.v8]
+version = "0.9.1"
+optional = true
+
 [features]
 shared = ["v8/shared"]
+default = ["v8"]
 
 [profile]
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,7 @@ use serde_yaml;
 use std::io;
 use std::string;
 use toml;
+#[cfg(feature = "v8")]
 use v8;
 use xdg_basedir;
 use yaml_rust;
@@ -18,7 +19,7 @@ error_chain! {
     links {
         Avro(serde_avro::error::Error, serde_avro::error::ErrorKind);
         Protobuf(serde_protobuf::error::Error, serde_protobuf::error::ErrorKind);
-        V8(v8::error::Error, v8::error::ErrorKind);
+        V8(v8::error::Error, v8::error::ErrorKind) #[cfg(feature = "v8")];
     }
 
     foreign_links {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ extern crate serde_hjson;
 extern crate serde_json;
 extern crate serde_protobuf;
 extern crate serde_yaml;
+#[cfg(feature = "v8")]
 extern crate v8;
 extern crate xdg_basedir;
 extern crate toml;
@@ -30,6 +31,7 @@ extern crate yaml_rust;
 pub mod config;
 pub mod error;
 pub mod proto_index;
+#[cfg(feature = "v8")]
 pub mod query;
 pub mod value;
 
@@ -37,6 +39,7 @@ include!(concat!(env!("OUT_DIR"), "/build_info.rs"));
 
 pub const GIT_VERSION: &'static str = rq_git_version!();
 
+#[cfg(feature = "v8")]
 pub fn run_query<I, O>(query: &query::Query, source: I, mut sink: O) -> error::Result<()>
     where I: value::Source,
           O: value::Sink


### PR DESCRIPTION
Allow building more lightweight version of rq that only does conversions between formats and does not require `v8-sys`, a foreign dependency.