### PR TITLE
Add Nix to installation instructions

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -10,6 +10,7 @@ TODO: this section will soon be updated!
   * [GitHub releases](#github-releases) (Stable releases, fast)
   * [Arch Linux](#arch-linux) (Up to date, slow)
   * [Mac OS X](#mac-os-x) (Out of date, slow)
+  * [Nix](#nix) (Up to date, slow)
 
 ## Generic
 
@@ -58,3 +59,13 @@ If you for some reason want the last tagged release of `rq` (might be
 severely out of date):
 
     brew install rq
+
+## Nix
+
+`rq` is available in nixpkgs. You can install it via `nix-env`:
+
+    nix-env -i rq
+    
+ Or add to packages list if you use [Home Manager](https://github.com/rycee/home-manager):
+ 
+     home.packages = [ pkgs.rq ]


### PR DESCRIPTION
Not sure how to compare speed and freshness, but IMO nixpkgs is usually faster to update the registry than e.g. brew.

macOS installation doesn't work yet (https://github.com/NixOS/nixpkgs/pull/89527), but should be fine on Linux distros.