### PR TITLE
Fix building on Rust 1.51.0

### DIFF
--- a/src/value/avro.rs
+++ b/src/value/avro.rs
@@ -170,7 +170,7 @@ where
     fn drop(&mut self) {
         match self.0.flush() {
             Ok(_) => (),
-            Err(error) => panic!(error),
+            Err(error) => panic!("{}", error),
         }
     }
 }


### PR DESCRIPTION
rq currently fails to build on Rust 1.51.0 due to tripping the [`non-fmt-panic`](https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#non-fmt-panic) lint (and having `#![deny(warnings)]` set). This patch allows it to build on 1.51.0.